### PR TITLE
fix: access token after grant manager update

### DIFF
--- a/middleware/protect.js
+++ b/middleware/protect.js
@@ -31,7 +31,7 @@ exports.default = (keycloak, spec) => {
     }
     return function protect(ctx, next) {
         if (ctx.state.kauth && ctx.state.kauth.grant) {
-            if (!guard || guard(ctx.state.kauth.grant.access_token, ctx)) {
+            if (!guard || guard(ctx.state.kauth.grant.accessToken, ctx)) {
                 return next();
             }
             return keycloak.accessDenied(ctx, next);

--- a/middleware/protect.ts
+++ b/middleware/protect.ts
@@ -38,7 +38,7 @@ export default (keycloak, spec) => {
 
   return function protect(ctx, next) {
     if (ctx.state.kauth && ctx.state.kauth.grant) {
-      if (!guard || guard(ctx.state.kauth.grant.access_token, ctx)) {
+      if (!guard || guard(ctx.state.kauth.grant.accessToken, ctx)) {
         return next();
       }
       return keycloak.accessDenied(ctx, next);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pixelygroup/keycloak-koa-connect",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pixelygroup/keycloak-koa-connect",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "keycloak koa oauth jsonWebToken",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`ctx.state.kauth.grant.access_token` needs to be changed to `ctx.state.kauth.grant.accessToken` 

Bug is related to the grant update, the grant manager updates access_token to accessToken before the protect() is called