### PR TITLE
fix: promise resolve with an argument

### DIFF
--- a/middleware/auth-utils/grant-manager.js
+++ b/middleware/auth-utils/grant-manager.js
@@ -318,7 +318,7 @@ class GrantManager {
                 this.validateToken(grant[tokenName])
                     .then((token) => {
                     grants[tokenName] = token;
-                    resolve();
+                    resolve(true);
                 })
                     .catch((err) => {
                     reject(new Error('Grant validation failed. Reason: ' + err.message));

--- a/middleware/auth-utils/grant-manager.ts
+++ b/middleware/auth-utils/grant-manager.ts
@@ -351,7 +351,7 @@ class GrantManager {
         this.validateToken(grant[tokenName])
           .then((token) => {
             grants[tokenName] = token;
-            resolve();
+            resolve(true);
           })
           .catch((err) => {
             reject(new Error('Grant validation failed. Reason: ' + err.message));

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,9 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -24,7 +23,7 @@ app.use(...keycloakKoaConnect.middleware());
 koaRouter.all('*', (ctx, next) => {
     ctx.body = 'Hello Koa';
 });
-appRouter.use('/', (ctx, next) => __awaiter(void 0, void 0, void 0, function* () {
+appRouter.use('/', (ctx, next) => __awaiter(this, void 0, void 0, function* () {
     try {
         yield keycloakKoaConnect.protect()(ctx, next);
         yield next();


### PR DESCRIPTION
More info at #15. Promise resolve/reject should come with at least one value to avoid `tsc` errors.